### PR TITLE
To-searching-in-new-group-registration

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -18,14 +18,13 @@ $(function(){
     function addGroupMember(userId, userName){
         let addMember = $('#add-group-users');
         let html = `<div class='chat-group-user clearfix js-chat-member' data-id='${userId}' data-name='${userName}'>
-        <input name='group[user_ids][]' type='hidden' value='${userId}'>
+        <input class='group_user_ids' name='group[user_ids][]' type='hidden' value='${userId}'>
         <p class='chat-group-user__name' data-id='${userId}'>${userName}</p>
         <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
       </div>`
       addMember.append(html);
     }
 
-   
     $('.user-search-remove').on('click',function(){
         $(this).parents('.chat-group-user').remove();
     })
@@ -34,15 +33,14 @@ $(function(){
         $('#add-user').empty();
         let input = $('#user-search-field').val(); 
         let inputWhiteSpace = input.split(" ").filter(function(e){
-            return e;
+            return e;     
         })
-        let groupId = $('#chat-group-users').data('group-id')
-      
+        
         if (input !== "" && inputWhiteSpace) {
             $.ajax({
                 type: 'GET',
                 url: '/users',
-                data: {name: input, group_id: groupId},
+                data: {name: input},
                 dataType: 'json'
             })
             .done(function(users){

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,11 @@
 class UsersController < ApplicationController
-  before_action :set_group, only: [:index]
 
-  def index    
-    @members = @group.users
-    @searchedUsers = User.where('name LIKE(?)', "#{params[:name]}%")
-    @users = @searchedUsers - @members
+  def index   
+    @users = User.where('name LIKE(?)', "#{params[:name]}%").where.not(id: current_user)
       respond_to do |format|
           format.html 
           format.json
-      end 
+      end
   end
 
   def edit
@@ -23,12 +20,9 @@ class UsersController < ApplicationController
   end
 
 private
+
   def user_params
     params.require(:user).permit(:name, :email)
-  end
-
-  def set_group
-    @group = Group.find(params[:group_id])
   end
 
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,7 +10,7 @@
       =f.label :name,  "グループ名", class: "chat-group-form__label",for: "chat_group_name"
     .chat-group-form__field--right
       =f.text_field :name, id: "chat_group_name", class: "chat-group-form__input", placeholder: "グループ名を入力してください"
-  .chat-group-form__field.clearfix#get-group-id{data:{group_id: group.id}}
+  .chat-group-form__field.clearfix#get-group-id
     =render partial: 'users/form'
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
@@ -18,13 +18,13 @@
     .chat-group-form__field--right
       %div{id:'chat-group-users', data:{group_id: group.id}}
         %div{class: 'chat-group-user clearfix',data:{id: current_user.id}}
-          %input{id:'group_user_ids', name:'group[user_ids][]', type:'hidden', value: current_user.id} 
+          %input{class:'group_user_ids', name:'group[user_ids][]', type:'hidden', value: current_user.id} 
           %p{class:'chat-group-user__name', data:{id: @users.ids}}
             =current_user.name        
       -@users.each do |user|
         -if (user.id != current_user.id)
           %div{class:'chat-group-user clearfix', data:{id: user.id, name: user.name}}
-            %input{id: 'group_user_ids', name:'group[user_ids][]', type:'hidden', value: user.id}
+            %input{class: 'group_user_ids', name:'group[user_ids][]', type:'hidden', value: user.id}
             %p.chat-group-user__name
               =user.name
             %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除


### PR DESCRIPTION
# WHAT インクリメンタルサーチの修正
## WHY　デプロイしたところ、新規登録画面でインクリメンタルサーチができなかった。理由としてはグループ編集画面においてインメンタルサーチの表示する人が既にいるメンバーと重複しないように、groupのidをajaxから飛ばすことで実装していたが、新規登録画面ではgroupのidが無理がnilになるためajax通信が起動しなくなり不可能に。ajax通信で別の方法で２通り試しみたが、複数のusr_idをajax通信で送る、というところで実装できなくなり、断念。後から聞くと応用実装範囲のところということで、とりあえず、メンバー重複はあるものの、新規登録画面、編集画面でインクリメンタルサーチができるように修正いたしました。